### PR TITLE
Add support for large RRFS natlev large grib2 files

### DIFF
--- a/sorc/chgres_cube.fd/atm_input_data.F90
+++ b/sorc/chgres_cube.fd/atm_input_data.F90
@@ -2065,8 +2065,8 @@ implicit none
    jpdtn   = -1     ! Search for any product definition template number.
    unpack  =.false.
 
-   call getgb2(lugb, lugi, j, jdisc, jids, jpdtn, jpdt, jgdtn, jgdt, &
-             unpack, k, gfld, iret)
+   call getgb2i2(lugb, lugi , j, jdisc, jids, jpdtn, jpdt, jgdtn, jgdt, &
+             unpack, 2, k, gfld, iret)
 
 !----------------------------------------------------------------------
 ! Read first record and check if this is NCEP GEFS data. 

--- a/sorc/chgres_cube.fd/model_grid.F90
+++ b/sorc/chgres_cube.fd/model_grid.F90
@@ -667,8 +667,8 @@
  jpdt    = -9999  ! Array of values in product definition template, set to wildcard.
  unpack  = .false. ! unpack data
    
- call getgb2(lugb, lugi, j, jdisc, jids, jpdtn, jpdt, jgdtn, jgdt, &
-             unpack, k, gfld, rc)
+ call getgb2i2(lugb, lugi, j, jdisc, jids, jpdtn, jpdt, jgdtn, jgdt, &
+             unpack, 2, k, gfld, rc)
  if (rc /= 0) call error_handler("DEGRIBBING INPUT FILE.", rc)
 
  call baclose(lugb,rc)

--- a/sorc/chgres_cube.fd/sfc_input_data.F90
+++ b/sorc/chgres_cube.fd/sfc_input_data.F90
@@ -1808,7 +1808,7 @@ module sfc_input_data
 
    if (localpet == 0) then
 
-     lugb=12
+     lugb=16
      call baopenr(lugb,the_file,rc)
      if (rc /= 0) call error_handler("ERROR OPENING GRIB2 FILE.", rc)
 
@@ -1822,8 +1822,8 @@ module sfc_input_data
      jpdt    = -9999  ! array of values in product definition template, set to wildcard
      unpack  = .false. ! unpack data
 
-     call getgb2(lugb, lugi, j, jdisc, jids, jpdtn, jpdt, jgdtn, jgdt, &
-             unpack, k, gfld, rc)
+     call getgb2i2(lugb, lugi, j, jdisc, jids, jpdtn, jpdt, jgdtn, jgdt, &
+             unpack, 2, k, gfld, rc)
 
      if (rc == 0) then
        if (gfld%idsect(1) == 7 .and. gfld%idsect(2) == 2) then


### PR DESCRIPTION
Add support for large RRFS natlev large grib2 files. This requires g2v3.4.9 or greater to create index files for large files.

Change introduced by larissa.reames@noaa.gov 


## DESCRIPTION OF CHANGES: 
Large grib2 files from RRFSv1 forecasts, downloaded from https://registry.opendata.aws/noaa-rrfs/ generate error when data from grib2 files are read on vertical  levels using the currently used chgres_cube, as part of SRW workflow tasks `make_ics` and `make_lbcs`.

## TESTS CONDUCTED: 
A small domain over the California region was chosen (Mountain Fire, over Ventura area, fire on Nov. 6-14, 2024). Native grib2 files are no longer available for the dates of the fire. The last date of the RRFSv1 forecasts was used, 20241203, and the SRW forecast was configured for a 3-h forecast, retrieving the native level large grib2 files. 
Processing of the initial and lateral boundary conditions was successfully completed by the `make_ics_mem000` and `make_lbcs_mem000` workflow tasks. It also required modifications of the task submission scripts, and use "bigmem" partition . 
Forecast finishes successfully 
Logs for the workflow tasks `make_ics_mem000` ,`make_lbcs_mem000`, and `run_fcst_mem000` from the test on Hera, in /scratch2/NCEPDEV/stmp1/Natalie.Perlin/SRW1/expt_dirs/test_RRFS_1km_CA/, 
are attached.

[log.RRFS_natlev_grib2_make_ics_mem000_2024120300.txt](https://github.com/user-attachments/files/18968088/log.RRFS_natlev_grib2_make_ics_mem000_2024120300.txt)
[log.RRFS_natlev_grib2_make_lbcs_mem000_2024120300.txt](https://github.com/user-attachments/files/18968094/log.RRFS_natlev_grib2_make_lbcs_mem000_2024120300.txt)
[log.RRFS_natlev_grib2_run_fcst_mem000_2024120300.txt](https://github.com/user-attachments/files/18968103/log.RRFS_natlev_grib2_run_fcst_mem000_2024120300.txt)

- [ ] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera, Hercules and WCOSS2).
- [ ] Compile branch on Hera using GNU.
- [ ] Compile branch in 'Debug' mode on WCOSS2.
- [ ] Run unit tests locally on any Tier 1 machine.
- [ ] Run relevant consistency tests locally on all Tier 1 machines.

Optional test.

- [ ] Run full set of chgres_cube consistency tests on Hera.

Describe any additional tests performed.

## DEPENDENCIES:
Add any links to pending PRs that are required prior to merging this PR. For example:

ufs-community/UFS_UTILS/pull/<pr_number>

## DOCUMENTATION:
If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files in the docs/source directory as supporting material.

## ISSUE: 
https://github.com/ufs-community/ufs-srweather-app/issues/1191

## CONTRIBUTORS (optional): 

@LarissaReames-NOAA (https://github.com/LarissaReames-NOAA) introduced the changes in her branch feature/large_grib2:
https://github.com/LarissaReames-NOAA/UFS_UTILS/tree/feature/large_grib2

The branch also included more updated UFS_UTILS commits that are not yet introduced to the NOAA-EPIC/UFS_UTILS srw-v3.3.0 branch
Changes similar to @LarissaReames-NOAA to the files 
./sorc/chgres_cube.fd/atm_input_data.F90
./sorc/chgres_cube.fd/sfc_input_data.F90
./sorc/chgres_cube.fd/model_grid.F90
solved the issue.