### PR TITLE
[release/srw-v3.0.0] Address warning messages while compiling UFS_UTILS

### DIFF
--- a/sorc/fre-nctools.fd/shared_lib/create_xgrid.c
+++ b/sorc/fre-nctools.fd/shared_lib/create_xgrid.c
@@ -2115,7 +2115,7 @@ double poly_ctrlon(const double x[], const double y[], int n, double clon)
     if( dphi2 > M_PI) dphi2 -= 2.0*M_PI;
     if( dphi2 <-M_PI) dphi2 += 2.0*M_PI;    
 
-    if(abs(dphi2 -dphi1) < M_PI) {
+    if(fabs(dphi2 -dphi1) < M_PI) {
       ctrlon -= dphi * (dphi1*f1+dphi2*f2)/2.0;
     }
     else {
@@ -2123,7 +2123,7 @@ double poly_ctrlon(const double x[], const double y[], int n, double clon)
 	fac = M_PI;
       else
 	fac = -M_PI;
-      fint = f1 + (f2-f1)*(fac-dphi1)/abs(dphi);
+      fint = f1 + (f2-f1)*(fac-dphi1)/fabs(dphi);
       ctrlon -= 0.5*dphi1*(dphi1-fac)*f1 - 0.5*dphi2*(dphi2+fac)*f2
 	+ 0.5*fac*(dphi1+dphi2)*fint;
 	}
@@ -2183,7 +2183,7 @@ double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, do
     if( dphi2 > M_PI) dphi2 -= 2.0*M_PI;
     if( dphi2 <-M_PI) dphi2 += 2.0*M_PI;    
 
-    if(abs(dphi2 -dphi1) < M_PI) {
+    if(fabs(dphi2 -dphi1) < M_PI) {
       ctrlon -= dphi * (dphi1*f1+dphi2*f2)/2.0;
     }
     else {
@@ -2191,7 +2191,7 @@ double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, do
 	fac = M_PI;
       else
 	fac = -M_PI;
-      fint = f1 + (f2-f1)*(fac-dphi1)/abs(dphi);
+      fint = f1 + (f2-f1)*(fac-dphi1)/fabs(dphi);
       ctrlon -= 0.5*dphi1*(dphi1-fac)*f1 - 0.5*dphi2*(dphi2+fac)*f2
 	+ 0.5*fac*(dphi1+dphi2)*fint;
     }

--- a/sorc/fre-nctools.fd/shared_lib/interp.c
+++ b/sorc/fre-nctools.fd/shared_lib/interp.c
@@ -78,7 +78,7 @@ End slopes
      d[0] = 0.0;
   }
   else {
-     if ( delta[0]*delta[1] < 0.0 && abs(d[0]) > abs(3.0*delta[0])) {
+     if ( delta[0]*delta[1] < 0.0 && fabs(d[0]) > fabs(3.0*delta[0])) {
         d[0]=3.0*delta[0];
      }
   }
@@ -88,7 +88,7 @@ End slopes
      d[kmax] = 0.0;
   }
   else {
-     if ( delta[kmax-1]*delta[kmax-2] < 0.0 && abs(d[kmax]) > abs(3.0*delta[kmax-1])) {
+     if ( delta[kmax-1]*delta[kmax-2] < 0.0 && fabs(d[kmax]) > fabs(3.0*delta[kmax-1])) {
         d[kmax]=3.0*delta[kmax-1];
      }
   }

--- a/sorc/fre-nctools.fd/shared_lib/mosaic_util.c
+++ b/sorc/fre-nctools.fd/shared_lib/mosaic_util.c
@@ -528,8 +528,8 @@ double spherical_angle(const double *v1, const double *v2, const double *v3)
     angle = 0. ;
   else {
     ddd = (px*qx+py*qy+pz*qz) / sqrt(ddd);
-    if( fabs(ddd-1) < EPSLN30 ) ddd = 1;
-    if( fabs(ddd+1) < EPSLN30 ) ddd = -1;
+    if( fabsl(ddd-1) < EPSLN30 ) ddd = 1;
+    if( fabsl(ddd+1) < EPSLN30 ) ddd = -1;
     if ( ddd>1. || ddd<-1. ) {
       /*FIX (lmh) to correctly handle co-linear points (angle near pi or 0) */
       if (ddd < 0.)
@@ -731,7 +731,7 @@ int invert_matrix_3x3(long double m[], long double m_inv[]) {
 #ifdef test_invert_matrix_3x3
   printf("det = %Lf\n", det);
 #endif  
-  if (fabs(det) < EPSLN15 ) return 0;
+  if (fabsl(det) < EPSLN15 ) return 0;
 
   const long double deti = 1.0/det;
 

--- a/sorc/fre-nctools.fd/shared_lib/mosaic_util.h
+++ b/sorc/fre-nctools.fd/shared_lib/mosaic_util.h
@@ -63,6 +63,8 @@ void initNode(struct Node *node);
 void addEnd(struct Node *list, double x, double y, double z, int intersect, double u, int inbound, int inside);
 int addIntersect(struct Node *list, double x, double y, double z, int intersect, double u1, double u2, 
                 int inbound, int is1, int ie1, int is2, int ie2);
+void insertIntersect(struct Node *list, double x, double y, double z, double u1, double u2, int inbound,
+                 double x2, double y2, double z2);
 int length(struct Node *list);
 int samePoint(double x1, double y1, double z1, double x2, double y2, double z2);
 int sameNode(struct Node node1, struct Node node2);

--- a/sorc/fre-nctools.fd/tools/make_hgrid/make_hgrid.c
+++ b/sorc/fre-nctools.fd/tools/make_hgrid/make_hgrid.c
@@ -1037,7 +1037,7 @@ int main(int argc, char* argv[])
     }
     }
     
-    if (verbose) fprintf(stderr, "[INFO] Allocating arrays of size %d for x, y based on nxp: %d nyp: %d ntiles: %d\n", size1, nxp, nyp, ntiles);
+    if (verbose) fprintf(stderr, "[INFO] Allocating arrays of size %lu for x, y based on nxp: %d nyp: %d ntiles: %d\n", size1, nxp, nyp, ntiles);
     x        = (double *) malloc(size1*sizeof(double));
     y        = (double *) malloc(size1*sizeof(double));
     area     = (double *) malloc(size4*sizeof(double));
@@ -1198,7 +1198,7 @@ int main(int argc, char* argv[])
 
       if(out_halo ==0) {
         if (verbose) {
-          fprintf(stderr, "[INFO] START NC XARRAY write out_halo=0 tile number = n: %d offset = pos_c: %d\n", n, pos_c);
+          fprintf(stderr, "[INFO] START NC XARRAY write out_halo=0 tile number = n: %d offset = pos_c: %ld\n", n, pos_c);
           fprintf(stderr, "[INFO] XARRAY: n: %d x[0]: %f x[1]: %f x[2]: %f x[3]: %f x[4]: %f x[5]: %f x[10]: %f\n",
                   n, x[pos_c], x[pos_c+1], x[pos_c+2], x[pos_c+3], x[pos_c+4], x[pos_c+5], x[pos_c+10]);
           if (n > 0) fprintf(stderr, "[INFO] XARRAY: n: %d x[0]: %f x[-1]: %f x[-2]: %f x[-3]: %f x[-4]: %f x[-5]: %f x[-10]: %f\n",
@@ -1259,9 +1259,9 @@ int main(int argc, char* argv[])
       nxp = nx + 1;
       nyp = ny + 1;
 
-      if (verbose) fprintf(stderr, "[INFO] INDEX Before increment n: %d pos_c %d nxp %d nyp %d nxp*nyp %d\n", n, pos_c, nxp, nyp, nxp*nyp);
+      if (verbose) fprintf(stderr, "[INFO] INDEX Before increment n: %d pos_c %ld nxp %d nyp %d nxp*nyp %d\n", n, pos_c, nxp, nyp, nxp*nyp);
       pos_c += nxp*nyp;
-      if (verbose) fprintf(stderr, "[INFO] INDEX After increment n: %d pos_c %d.\n", n, pos_c);
+      if (verbose) fprintf(stderr, "[INFO] INDEX After increment n: %d pos_c %ld.\n", n, pos_c);
       pos_e += nxp*ny;
       pos_n += nx*nyp;
       pos_t += nx*ny;


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
 * sorc/fre-nctools.fd/shared_lib/create_xgrid.c - Replace abs with fabs to address warnings while compiling
 * sorc/fre-nctools.fd/shared_lib/interp.c - Replace abs with fabs to address warnings while compiling
 * sorc/fre-nctools.fd/shared_lib/mosaic_util.c - Replace fabs with fabsl to address warnings while compiling
 * sorc/fre-nctools.fd/shared_lib/mosaic_util.h - Add "void insertIntersect" to address warnings (and errors for newer Intel compilers)
 * sorc/fre-nctools.fd/tools/make_hgrid/make_hgrid.c - Replace `d` with `lu` and `d` with `ld` to address warnings while compiling

These changes were applied in PR [#969](https://github.com/ufs-community/UFS_UTILS/pull/969) and PR [#996](https://github.com/ufs-community/UFS_UTILS/pull/996) in the authoritative UFS_UTILS repository.

These changes are required in order to build UFS_UTILS using the updated Intel compilers used in spack-stack 1.9.2, as several of the current warnings become errors with these Intel compilers.
## TESTS CONDUCTED: 
These changes were tested on Hera Intel -

The fundamental WE2E tests successfully passed:
```
----------------------------------------------------------------------------------------------------
Experiment name                                                  | Status    | Core hours used 
----------------------------------------------------------------------------------------------------
grid_RRFS_CONUScompact_25km_ics_RRFS_lbcs_RRFS_suite_RRFS_sas_202  COMPLETE              14.42
custom_ESGgrid_Central_Asia_3km_20250717163135                     COMPLETE              69.60
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v17_p8_plot  COMPLETE              17.15
grid_RRFS_CONUScompact_25km_ics_HRRR_lbcs_HRRR_suite_HRRR_2025071  COMPLETE              43.39
grid_SUBCONUS_Ind_3km_ics_HRRR_lbcs_RAP_suite_WoFS_v0_20250717163  COMPLETE              24.84
grid_RRFS_CONUS_25km_ics_NAM_lbcs_NAM_suite_GFS_v16_2025071716325  COMPLETE              30.02
----------------------------------------------------------------------------------------------------
Total                                                              COMPLETE             199.42
```
the AQM WE2E test successfully passed:
```
----------------------------------------------------------------------------------------------------
Experiment name                                                  | Status    | Core hours used
----------------------------------------------------------------------------------------------------
aqm_grid_AQM_NA13km_suite_GFS_v16_20250717181821                   COMPLETE            6010.07
----------------------------------------------------------------------------------------------------
Total                                                              COMPLETE            6010.07
```
and the UFS-Fire WE2E tests successfully passed:
```
----------------------------------------------------------------------------------------------------
Experiment name                                                  | Status    | Core hours used 
----------------------------------------------------------------------------------------------------
UFS_FIRE_one-way-coupled_20250717172939                            COMPLETE              35.96
UFS_FIRE_multifire_two-way-coupled_20250717172957                  COMPLETE              38.96
----------------------------------------------------------------------------------------------------
Total                                                              COMPLETE              74.92
```